### PR TITLE
Solved the None issue in the param variable

### DIFF
--- a/pexels_async_api/client.py
+++ b/pexels_async_api/client.py
@@ -34,7 +34,10 @@ class AsyncPexelsClient:
                           max_tries=8)
     async def _make_request(self, endpoint, params=None):
         headers = {"Authorization": self.api_key}
-        params = {k: v for k, v in params.items() if v is not None}  # remove None values
+        if params is not None:  # Only process params if it's not None
+            params = {k: v for k, v in params.items() if v is not None}  # Remove None values
+        else:
+            params = {}  # Use an empty dict if params is None
         async with aiohttp.ClientSession() as session:
             async with session.get(f"{self.base_url}/{endpoint}", headers=headers, params=params) as response:
                 response.raise_for_status()


### PR DESCRIPTION
The video downloader doesn't work on newer python versions because the param variable is init at None by default and we try to read params.items(). params being None, items is not found and it throws an error.

I just checked if params is not None and if it is just et it to en empty dict